### PR TITLE
Add missing React & JSX eslint rules

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/package.json
+++ b/packages/eslint-config-eventbrite-legacy/package.json
@@ -35,7 +35,7 @@
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "eslint": ">=2.5.3"
+    "eslint": "^2.5.3"
   },
   "engines": {
     "node": ">=0.10"

--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -45,7 +45,6 @@
     "babel-eslint": "^6.0.0",
     "eslint": "^2.5.3",
     "eslint-plugin-jsx-a11y": "^1.2.2",
-    "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-react": "^5.1.1"
   },
   "engines": {

--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -38,14 +38,15 @@
     "eslint": "^2.5.3",
     "eslint-config-eventbrite-legacy": "../eslint-config-eventbrite-legacy",
     "eslint-plugin-jsx-a11y": "^1.2.2",
-    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react": "^5.1.1",
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "babel-eslint": ">=6.0.0",
-    "eslint": ">=2.5.3",
-    "eslint-plugin-jsx-a11y": ">=1.2.2",
-    "eslint-plugin-react": ">=4.2.3"
+    "babel-eslint": "^6.0.0",
+    "eslint": "^2.5.3",
+    "eslint-plugin-jsx-a11y": "^1.2.2",
+    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react": "^5.1.1"
   },
   "engines": {
     "node": ">=0.10"

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -49,15 +49,13 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
         'react/jsx-handler-names': 'error',
 
-        // Do not enforce specific JSX tag indentation
-        // NOTE: We DO want to force indentation but would want 4 spaces OR 1 tab
+        // Enforce 4 space JSX tag indentation
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
-        'react/jsx-indent': 'off',
+        'react/jsx-indent': 'error',
 
-        // Do not enforce specific JSX props indentation
-        // NOTE: We DO want to force indentation but would want 4 spaces OR 1 tab
+        // Enforce 4 space JSX props indentation
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
-        'react/jsx-indent-props': 'off',
+        'react/jsx-indent-props': 'error',
 
         // Validate JSX has key prop when in array or iterator
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -21,13 +21,13 @@ module.exports = {
         // http://eslint.org/docs/rules/jsx-quotes
         'jsx-quotes': 'error',
 
-        // True boolean props must pass {true} value
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-        'react/jsx-boolean-value': ['error', 'always'],
-
         // Forbid propTypes: any, array, object
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md
         'react/forbid-prop-types': 'error',
+
+        // True boolean props must pass {true} value
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
+        'react/jsx-boolean-value': ['error', 'always'],
 
         // Validate closing bracket location in JSX is aligned with opening tag
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
@@ -41,24 +41,87 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
         'react/jsx-equals-spacing': 'error',
 
+        // Enforce that the first property should always be placed on a new line when the properties are spread over multiple lines
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
+        'react/jsx-first-prop-new-line': ['error', 'multiline'],
+
         // Enforce event handler naming conventions in JSX: on* for props, handle* from functions
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
         'react/jsx-handler-names': 'error',
+
+        // Do not enforce specific JSX tag indentation
+        // NOTE: We DO want to force indentation but would want 4 spaces OR 1 tab
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
+        'react/jsx-indent': 'off',
+
+        // Do not enforce specific JSX props indentation
+        // NOTE: We DO want to force indentation but would want 4 spaces OR 1 tab
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
+        'react/jsx-indent-props': 'off',
 
         // Validate JSX has key prop when in array or iterator
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
         'react/jsx-key': 'error',
 
+        // Limit maximum of props on a single line in JSX to 3
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
+        'react/jsx-max-props-per-line': ['error', {maximum: 3}],
+
+        // Prevent arrow functions & refs in a JSX prop (but still allow bind for now)
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
+        'react/jsx-no-bind': ['error', {
+            allowBind: true
+        }],
+
+        // Prevent usage of unsafe target="_blank" w/o rel="noopener noreferrer"
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
+        'react/jsx-no-target-blank': 'error',
+
+        // Enforce PascalCase for user-defined JSX components
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
+        'react/jsx-pascal-case': 'error',
+
+        // Enforce that there's a space before the closing bracket of self-closing JSX elements
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+        'react/jsx-space-before-closing': 'error',
+
         // Warn when using "dangerous" JSX properties
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
         'react/no-danger': 'warn',
+
+        // Prevent multiple component definitions in a given file
+        // (stateless helper components are ok)
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
+        'react/no-multi-comp': ['error', {ignoreStateless: true}],
+
+        // Prevent using (legacy) string references in ref attribute
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
+        'react/no-string-refs': 'error',
 
         // Require ES6 class declarations over React.createClass
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
         'react/prefer-es6-class': 'error',
 
+        // Do not enforce stateless React Components to be written as a pure function
+        // TODO: Consider enabling in the future because they will benefit from
+        // future performance optimizations
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
+        'react/prefer-stateless-function': 'off',
+
+        // Enforce that ES6 class returns a value for `render()` method
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
+        'react/require-render-return': 'error',
+
+        // Enforce that components are self-closed when they don't have content
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+        'react/self-closing-comp': 'error',
+
         // Enforce default component methods order
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
-        'react/sort-comp': 'error'
+        'react/sort-comp': 'error',
+
+        // Enforce multi-line JSX is wrapped in parentheses
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
+        'react/wrap-multilines': 'error'
     }
 };

--- a/packages/eslint-config-eventbrite/package.json
+++ b/packages/eslint-config-eventbrite/package.json
@@ -38,7 +38,7 @@
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "eslint": ">=2.5.3"
+    "eslint": "^2.5.3"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
Also changing the peerDependencies back to using caret syntax since it's possible that we'll add new rules not available in previous versions of packages