### PR TITLE
Relaxing some ESLint rules

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/README.md
+++ b/packages/eslint-config-eventbrite-legacy/README.md
@@ -21,9 +21,7 @@ Extend `eslint-config-eventbrite-legacy` in your [`.eslintrc.json`](http://eslin
 
 ```json
 {
-    "extends": [
-        "eventbrite-legacy"
-    ]
+    "extends": "eventbrite-legacy"
 }
 ```
 

--- a/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
@@ -171,9 +171,10 @@ module.exports = {
         // http://eslint.org/docs/rules/no-unmodified-loop-condition
         'no-unmodified-loop-condition': 'error',
 
-        // disallow usage of expressions in statement position
+        // (temporarily) Allow usage of expressions in statement position
+        // TODO: Reenable once we can figure out a workaround with Chai expect()
         // http://eslint.org/docs/rules/no-unused-expressions
-        'no-unused-expressions': 'error',
+        'no-unused-expressions': 'off',
 
         // disallow unnecessary .call() and .apply()
         // http://eslint.org/docs/rules/no-useless-call

--- a/packages/eslint-config-eventbrite-react/README.md
+++ b/packages/eslint-config-eventbrite-react/README.md
@@ -9,7 +9,7 @@ Eventbrite's ESLint config that lints React & JSX, adhering to the [Eventbrite J
 
 ## Usage
 
-This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) and [`babel-eslint`](https://github.com/babel/babel-eslint).
+This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y/) and [`babel-eslint`](https://github.com/babel/babel-eslint).
 
 Install `eslint`, `eslint-plugin-react`, `eslint-plugin-jsx-a11y`, `babel-eslint` & `eslint-config-eventbrite-react` dependencies:
 
@@ -21,9 +21,7 @@ Extend `eslint-config-eventbrite-react` in your [`.eslintrc.json`](http://eslint
 
 ```json
 {
-    "extends": [
-        "eventbrite-react"
-    ]
+    "extends": "eventbrite-react"
 }
 ```
 

--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -5,7 +5,7 @@ module.exports = {
     ],
 
     // View link below for docs on react a11y rules
-    // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/
     rules: {
         // Enforce all `aria-*` props are valid
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md

--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -36,9 +36,9 @@ module.exports = {
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
         'jsx-a11y/img-redundant-alt': 'error',
 
-        // Enforce that `<label>` elements have the `htmlFor` prop
+        // Enforce that `<label>` & (custom) <Label> elements have the `htmlFor` prop
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-        'jsx-a11y/label-has-for': 'error',
+        'jsx-a11y/label-has-for': ['error', 'Label'],
 
         // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur
         // for keyboard-only users

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -106,6 +106,11 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
         'react/prefer-stateless-function': 'off',
 
+        // (temporary) Allow missing props validation in a React component definition
+        // TODO: Reenable once we're able to configure it to ignore stateless functions (our helper components)
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
+        'react/prop-types': 'off',
+
         // Enforce that ES6 class returns a value for `render()` method
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
         'react/require-render-return': 'error',

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -61,9 +61,9 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
         'react/jsx-key': 'error',
 
-        // Limit maximum of props on a single line in JSX to 4
+        // Limit maximum of props on a single line in JSX to 3
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
-        'react/jsx-max-props-per-line': ['error', {maximum: 4}],
+        'react/jsx-max-props-per-line': ['error', {maximum: 3}],
 
         // Prevent arrow functions & refs in a JSX prop (but still allow bind for now)
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -61,9 +61,9 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
         'react/jsx-key': 'error',
 
-        // Limit maximum of props on a single line in JSX to 3
+        // Limit maximum of props on a single line in JSX to 4
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
-        'react/jsx-max-props-per-line': ['error', {maximum: 3}],
+        'react/jsx-max-props-per-line': ['error', {maximum: 4}],
 
         // Prevent arrow functions & refs in a JSX prop (but still allow bind for now)
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

--- a/packages/eslint-config-eventbrite/README.md
+++ b/packages/eslint-config-eventbrite/README.md
@@ -9,21 +9,19 @@ Eventbrite's base ESLint config that lints ES6+/ES2015+ and adheres to the [Even
 
 ## Usage
 
-This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint).
+This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint) and [`babel-eslint`](https://github.com/babel/babel-eslint).
 
-Install `eslint` & `eslint-config-eventbrite` dependencies:
+Install `eslint`, `babel-eslint` & `eslint-config-eventbrite` dependencies:
 
 ```sh
-npm install --save-dev eslint eslint-config-eventbrite
+npm install --save-dev eslint babel-eslint eslint-config-eventbrite
 ```
 
 Extend `eslint-config-eventbrite` in your [`.eslintrc.json`](http://eslint.org/docs/user-guide/configuring#extending-configuration-files):
 
 ```json
 {
-    "extends": [
-        "eventbrite"
-    ]
+    "extends": "eventbrite"
 }
 ```
 

--- a/packages/eslint-config-eventbrite/index.js
+++ b/packages/eslint-config-eventbrite/index.js
@@ -3,6 +3,7 @@ module.exports = {
         './rules/best-practices',
         './rules/errors',
         './rules/es6',
+        './rules/esnext',
         './rules/style'
     ].map(require.resolve))
 };

--- a/packages/eslint-config-eventbrite/package.json
+++ b/packages/eslint-config-eventbrite/package.json
@@ -36,10 +36,12 @@
     "eslint-config-eventbrite-legacy": "^1.0.0"
   },
   "devDependencies": {
+    "babel-eslint": "^6.0.0",
     "eslint": "^2.11.1",
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
+    "babel-eslint": "^6.0.0",
     "eslint": "^2.11.1"
   },
   "engines": {

--- a/packages/eslint-config-eventbrite/rules/errors.js
+++ b/packages/eslint-config-eventbrite/rules/errors.js
@@ -6,6 +6,6 @@ module.exports = {
         // closing ] or } and disallows trailing commas when the last
         // element or property is on the same line as the closing ] or }
         // http://eslint.org/docs/rules/comma-dangle
-        'comma-dangle': 'error'
+        'comma-dangle': ['error', 'only-multiline']
     }
 };

--- a/packages/eslint-config-eventbrite/rules/es6.js
+++ b/packages/eslint-config-eventbrite/rules/es6.js
@@ -20,7 +20,7 @@ module.exports = {
         // disallow arrow functions where they could be confused with comparisons
         // unless a parentheses are used to disambiguate
         // http://eslint.org/docs/rules/no-confusing-arrow
-        'no-confusing-arrow': ['error', {allowParens: false}],
+        'no-confusing-arrow': ['error', {allowParens: true}],
 
         // disallow duplicate module imports & exports
         // http://eslint.org/docs/rules/no-duplicate-imports
@@ -34,9 +34,10 @@ module.exports = {
         // http://eslint.org/docs/rules/no-useless-constructor
         'no-useless-constructor': 'error',
 
-        // disallow renaming import, export, and destructured assignments to the same name
+        // disallow renaming export and destructured assignments to the same name
+        // imports are ignored because they seem to generate false positives
         // http://eslint.org/docs/rules/no-useless-rename
-        'no-useless-rename': 'error',
+        'no-useless-rename': ['error', {ignoreImport: true}],
 
         // require use of let & const
         // http://eslint.org/docs/rules/no-var

--- a/packages/eslint-config-eventbrite/rules/esnext.js
+++ b/packages/eslint-config-eventbrite/rules/esnext.js
@@ -1,0 +1,13 @@
+module.exports = {
+    parser: 'babel-eslint',
+    parserOptions: {
+        ecmaVersion: 7,
+        sourceType: 'module',
+        ecmaFeatures: {
+        }
+    },
+
+    rules: {
+
+    }
+};

--- a/packages/eslint-config-eventbrite/rules/style.js
+++ b/packages/eslint-config-eventbrite/rules/style.js
@@ -3,7 +3,7 @@ module.exports = {
     rules: {
         // Enforce function expressions
         // http://eslint.org/docs/rules/func-style
-        'func-style': 'error',
+        'func-style': ['error', 'expression'],
 
         // enforce that `let` & `const` declarations are declared together
         // http://eslint.org/docs/rules/one-var


### PR DESCRIPTION
Changes include:

- (temporarily) turning off `no-unused-expressions` until we can figure out a solution to make it work with chai's expectation syntax that looks like unused expressions
- (temporarily) turning off `react/prop-types` until we can implement the update so that it ignores stateless functions that we use for helper components and don't want to define `propTypes` for
- `eslint-config-eventbrite` depends on `babel-eslint` so it can lint ES2016+ and provided a place for ES2016+ rules to go
- `comma-dangle` allows dangling commas for multi-line things
- only function expressions (arrow functions) allowed in ES6+
- ignore imports for `no-useless-rename`
- set `allowParens` to `true` for `no-confusing-arrow` (i.e. arrow functions aren't confusing if you use parentheses)
- validate `htmlFor` on `Label` component as well