### PR TITLE
Removed extra space from general-multi_if_statement

### DIFF
--- a/general/README.md
+++ b/general/README.md
@@ -71,7 +71,7 @@ this[whatToDoWithTheThing]();
 // bad (mixed decisions and actions)
 if (this.something()) {
    /* do stuff */
-}  else if (this.otherSomething()) {
+} else if (this.otherSomething()) {
    /* do other stuff */
 } else if (this.somethingEvenMoreCurious()) {
    /* yet another thing */


### PR DESCRIPTION
Just a little typo here I think.