### PR TITLE
ESLint fixes from linting EB React codebase

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
@@ -32,7 +32,7 @@ module.exports = {
         // underscores in them
         // http://eslint.org/docs/rules/dot-notation
         'dot-notation': ['error', {
-            allowPattern: '^[a-z]+(_[a-z]+)+$'
+            allowPattern: '^[a-zA-Z0-9]+(_[a-zA-Z0-9]+)+$'
         }],
 
         // require use of === and !==

--- a/packages/eslint-config-eventbrite-legacy/rules/style.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/style.js
@@ -31,7 +31,9 @@ module.exports = {
 
         // 4-space indentation
         // http://eslint.org/docs/rules/indent
-        'indent': 'error',
+        'indent': ['error', 2, {
+            SwitchCase: 1
+        }],
 
         // space for values in object literals
         // http://eslint.org/docs/rules/key-spacing
@@ -88,9 +90,9 @@ module.exports = {
         // http://eslint.org/docs/rules/operator-assignment
         'operator-assignment': 'error',
 
-        // enforce operators to be placed before linebreaks
+        // don't enforce placement of operators with line breaks
         // http://eslint.org/docs/rules/operator-linebreak
-        'operator-linebreak': ['error', 'before'],
+        'operator-linebreak': 'off',
 
         // always use single quotes
         // http://eslint.org/docs/rules/quotes

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -45,9 +45,12 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
         'react/jsx-first-prop-new-line': ['error', 'multiline'],
 
-        // Enforce event handler naming conventions in JSX: on* for props, handle* from functions
+        // Enforce event handler naming conventions in JSX: on* for props, _handle* from methods/functions
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
-        'react/jsx-handler-names': 'error',
+        'react/jsx-handler-names': ['error', {
+            eventHandlerPrefix: '_handle',
+            eventHandlerPropPrefix: 'on'
+        }],
 
         // Enforce 4 space JSX tag indentation
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md


### PR DESCRIPTION
- `dot-notation` needs to handle uppercase snake_case
- `indent` needs to have normal indentation for `switch` blocks
- `operator-linebreak` should allow either placement
- `jsx-handler-names` should prefix `_handler` w/ underscore