### PR TITLE
Remove eslint globals + reenable no-unused-expressions rule

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/index.js
+++ b/packages/eslint-config-eventbrite-legacy/index.js
@@ -5,13 +5,5 @@ module.exports = {
         './rules/node',
         './rules/style',
         './rules/variables'
-    ].map(require.resolve)),
-    env: {
-        'amd': true,
-        'browser': true,
-        'jasmine': true
-    },
-    globals: {
-        'sinon': 1
-    }
+    ].map(require.resolve))
 };

--- a/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/best-practices.js
@@ -171,10 +171,9 @@ module.exports = {
         // http://eslint.org/docs/rules/no-unmodified-loop-condition
         'no-unmodified-loop-condition': 'error',
 
-        // (temporarily) Allow usage of expressions in statement position
-        // TODO: Reenable once we can figure out a workaround with Chai expect()
+        // disallow usage of expressions in statement position
         // http://eslint.org/docs/rules/no-unused-expressions
-        'no-unused-expressions': 'off',
+        'no-unused-expressions': 'error',
 
         // disallow unnecessary .call() and .apply()
         // http://eslint.org/docs/rules/no-useless-call


### PR DESCRIPTION
- Our individual repos should add app-specific eslint globals as needed instead of everyone implicitly inheriting them
- `no-unused-expressions` was turned off for chai matcher issues but should be turned off only in the repos with problems not everywhere