### PR TITLE
Fix eslint packages to have correct peerDeps/deps

### DIFF
--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -33,23 +33,17 @@
   },
   "homepage": "https://github.com/eventbrite/javascript#readme",
   "dependencies": {
-    "eslint-config-eventbrite": "^4.0.0"
+    "eslint-config-eventbrite": "^4.0.0",
+    "eslint-plugin-jsx-a11y": "^3.0.0",
+    "eslint-plugin-react": "^6.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.11.1",
-    "eslint-config-eventbrite-legacy": "^3.0.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^3.0.1",
-    "eslint-plugin-react": "^6.7.1",
+    "eslint": "^3.0.0",
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.0.0",
-    "eslint": "^3.0.0",
-    "eslint-plugin-import": "^2.0.0",
-    "eslint-plugin-jsx-a11y": "^3.0.0",
-    "eslint-plugin-react": "^6.0.0"
+    "eslint": "^3.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/eslint-config-eventbrite/package.json
+++ b/packages/eslint-config-eventbrite/package.json
@@ -33,18 +33,16 @@
   },
   "homepage": "https://github.com/eventbrite/javascript#readme",
   "dependencies": {
-    "eslint-config-eventbrite-legacy": "^3.0.0"
+    "eslint-config-eventbrite-legacy": "^3.0.0",
+    "eslint-plugin-import": "^2.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^3.11.1",
-    "eslint-plugin-import": "^2.2.0",
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.0.0",
     "eslint": "^3.0.0",
-    "eslint-plugin-import": "^2.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/eslint-config-eventbrite/package.json
+++ b/packages/eslint-config-eventbrite/package.json
@@ -42,7 +42,7 @@
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0",
+    "eslint": "^3.0.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Some packages that should have been hard dependencies were in peer, and packages that were extending from other packages were requesting the sub-dependencies as its own peer, so this diff is correcting that.