### PR TITLE
Replace old rules in jsx-a11y

### DIFF
--- a/packages/eslint-config-eventbrite-react/README.md
+++ b/packages/eslint-config-eventbrite-react/README.md
@@ -29,11 +29,8 @@ This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint),
 
 ```yarn add -D eslint-config-eventbrite-react```
 
-```sh
-npm install --save-dev eslint eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y babel-eslint eslint-config-eventbrite-react
-```
 
-Extend `eslint-config-eventbrite-react` in your [`.eslintrc.json`](http://eslint.org/docs/user-guide/configuring#extending-configuration-files):
+#### Extend `eslint-config-eventbrite-react` in your [`.eslintrc.json`](http://eslint.org/docs/user-guide/configuring#extending-configuration-files):
 
 ```json
 {

--- a/packages/eslint-config-eventbrite-react/README.md
+++ b/packages/eslint-config-eventbrite-react/README.md
@@ -11,18 +11,22 @@ Eventbrite's ESLint config that lints React & JSX, adhering to the [Eventbrite J
 
 This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint), [`eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y/) and [`babel-eslint`](https://github.com/babel/babel-eslint).
 
-- Install peer dependencies if they are not installed already
+#### Install peer dependencies if they are not installed already
+- Using npm
 
 ```npm install --save-dev eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0 eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0```
 
-Using yarn
+- Using yarn
+
 ```yarn add -D eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0 eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0```
 
-- Install eslint-config-eventbrite-react
+#### Install eslint-config-eventbrite-react
+- Using npm
 
 ```npm install --save-dev eslint-config-eventbrite-react```
 
-Using yarn
+- Using yarn
+
 ```yarn add -D eslint-config-eventbrite-react```
 
 ```sh

--- a/packages/eslint-config-eventbrite-react/README.md
+++ b/packages/eslint-config-eventbrite-react/README.md
@@ -11,16 +11,19 @@ Eventbrite's ESLint config that lints React & JSX, adhering to the [Eventbrite J
 
 This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint), [`eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y/) and [`babel-eslint`](https://github.com/babel/babel-eslint).
 
-Install peer dependencies if they are not installed already
-`npm install --save-dev eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0` eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0`
-or
-`yarn add -D eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0` eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0`
+- Install peer dependencies if they are not installed already
 
-Install eslint-config-eventbrite-react
+```npm install --save-dev eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0 eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0```
 
-`npm install --save-dev eslint-config-eventbrite-react`
-or
-`yarn add -D eslint-config-eventbrite-react`
+Using yarn
+```yarn add -D eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0 eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0```
+
+- Install eslint-config-eventbrite-react
+
+```npm install --save-dev eslint-config-eventbrite-react```
+
+Using yarn
+```yarn add -D eslint-config-eventbrite-react```
 
 ```sh
 npm install --save-dev eslint eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y babel-eslint eslint-config-eventbrite-react

--- a/packages/eslint-config-eventbrite-react/README.md
+++ b/packages/eslint-config-eventbrite-react/README.md
@@ -11,7 +11,16 @@ Eventbrite's ESLint config that lints React & JSX, adhering to the [Eventbrite J
 
 This ESLint configuration requires [`eslint`](https://github.com/eslint/eslint), [`eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import), [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react), [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y/) and [`babel-eslint`](https://github.com/babel/babel-eslint).
 
-Install `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-jsx-a11y`, `babel-eslint` & `eslint-config-eventbrite-react` dependencies:
+Install peer dependencies if they are not installed already
+`npm install --save-dev eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0` eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0`
+or
+`yarn add -D eslint@^3.0.0 eslint-plugin-import@^2.0.0 eslint-plugin-react@^6.0.0` eslint-plugin-jsx-a11y@^6.0.0 babel-eslint@^7.0.0`
+
+Install eslint-config-eventbrite-react
+
+`npm install --save-dev eslint-config-eventbrite-react`
+or
+`yarn add -D eslint-config-eventbrite-react`
 
 ```sh
 npm install --save-dev eslint eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y babel-eslint eslint-config-eventbrite-react

--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^3.11.1",
+    "eslint-config-eventbrite-legacy": "^3.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^6.7.1",

--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -40,7 +40,7 @@
     "eslint": "^3.11.1",
     "eslint-config-eventbrite-legacy": "^3.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^3.0.1",
+    "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^6.7.1",
     "pre-commit": "^1.1.2"
   },
@@ -48,7 +48,7 @@
     "babel-eslint": "^7.0.0",
     "eslint": "^3.0.0",
     "eslint-plugin-import": "^2.0.0",
-    "eslint-plugin-jsx-a11y": "^3.0.0",
+    "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^6.0.0"
   },
   "engines": {

--- a/packages/eslint-config-eventbrite-react/package.json
+++ b/packages/eslint-config-eventbrite-react/package.json
@@ -33,12 +33,11 @@
   },
   "homepage": "https://github.com/eventbrite/javascript#readme",
   "dependencies": {
-    "eslint-config-eventbrite": "^4.0.0"
+    "eslint-config-eventbrite": "^4.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^3.11.1",
-    "eslint-config-eventbrite-legacy": "^3.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^6.7.1",

--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -13,9 +13,9 @@ module.exports = {
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
         'jsx-a11y/anchor-has-content': 'error',
 
-        // Enforce an anchor element's `href` prop value is not just `#`
+        // Enforce an anchor element contains a valid `href` attribute and if it can be replaced by a button
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
-        'jsx-a11y/anchor-is-valid': 'error',
+        'jsx-a11y/anchor-is-valid': ['error', {components: ['Link']}],
 
         // Enforce all `aria-*` props are valid
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md

--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -1,41 +1,21 @@
+//NOTE: When adding new rules or modifying existing ones, make sure your changes are compatible with the existing version of the current `eslint-plugin-jsx-a11y` package. Also, don't forget to alphabetize below :)
 module.exports = {
     plugins: ['jsx-a11y'],
 
     // View link below for docs on react a11y rules
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/
     rules: {
+        // Enforce that `<img> <area> <input type="image"> <object>` JSX elements use the `alt` prop
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
+        'jsx-a11y/alt-text': 'error',
 
         // Enforce all anchors to contain accessible content.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
         'jsx-a11y/anchor-has-content': 'error',
 
-        // Enforce a clickable non-interactive element has at least one keyboard event listener.
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
-        'jsx-a11y/click-events-have-key-events': 'error',
-
-        // Enforce heading (h1, h2, etc) elements contain accessible content.
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
-        'jsx-a11y/heading-has-content': 'error',
-
-         // Enforce lang attribute has a valid value.
-         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
-        'jsx-a11y/lang': 'error',
-
-         // Enforce distracting elements are not used.
-         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md
-        'jsx-a11y/no-distracting-elements': 'error',
-
-         // Enforce explicit role property is not the same as implicit/default role property on element.
-         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
-        'jsx-a11y/no-redundant-roles': 'error',
-
-         // Enforce non-interactive elements have no interactive handlers.
-         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
-        'jsx-a11y/no-static-element-interactions': 'error',
-
-         // Enforce scope prop is only used on <th> elements.
-         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
-        'jsx-a11y/scope': 'error',
+        // Enforce an anchor element's `href` prop value is not just `#`
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+        'jsx-a11y/anchor-is-valid': 'error',
 
         // Enforce all `aria-*` props are valid
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
@@ -54,21 +34,29 @@ module.exports = {
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
         'jsx-a11y/aria-unsupported-elements': 'error',
 
-        // Enforce an anchor element's `href` prop value is not just `#`
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
-        'jsx-a11y/anchor-is-valid': 'error',
+        // Enforce a clickable non-interactive element has at least one keyboard event listener.
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
+        'jsx-a11y/click-events-have-key-events': 'error',
 
-        // Enforce that `<img> <area> <input type="image"> <object>` JSX elements use the `alt` prop
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
-        'jsx-a11y/alt-text': 'error',
+        // Enforce heading (h1, h2, etc) elements contain accessible content.
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
+        'jsx-a11y/heading-has-content': 'error',
 
         // Enforce `<img>` alt prop does not contain the word "image", "picture", or "photo"
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
         'jsx-a11y/img-redundant-alt': 'error',
 
+        // Enforce that elements with `onClick` handlers must be focusable
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
+        'jsx-a11y/interactive-supports-focus': 'error',
+
         // Enforce that `<label>` & (custom) <Label> elements have the `htmlFor` prop
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
         'jsx-a11y/label-has-for': ['error', {components: ['Label']}],
+
+         // Enforce lang attribute has a valid value.
+         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
+        'jsx-a11y/lang': 'error',
 
         // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur
         // for keyboard-only users
@@ -80,19 +68,27 @@ module.exports = {
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
         'jsx-a11y/no-access-key': 'error',
 
+         // Enforce distracting elements are not used.
+         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md
+        'jsx-a11y/no-distracting-elements': 'error',
+
         // Don't enforce that `onBlur` is used instead of (or more likely in parallel with) `onChange`
         // NOTE: We may want to consider this later, but this has UX implications
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
         'jsx-a11y/no-onchange': 'off',
 
-        // Enforce that elements with `onClick` handlers must be focusable
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
-        'jsx-a11y/interactive-supports-focus': 'error',
-
         // Enforce that non-interactive, visible elements (such as `<div>`)
         // that have click handlers use the role attribute
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md
         'jsx-a11y/no-noninteractive-element-interactions': 'error',
+
+        // Enforce explicit role property is not the same as implicit/default role property on element.
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
+        'jsx-a11y/no-redundant-roles': 'error',
+
+        // Enforce non-interactive elements have no interactive handlers.
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
+        'jsx-a11y/no-static-element-interactions': 'error',
 
         // Enforce that elements with ARIA roles must have all required attributes for that role
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
@@ -102,6 +98,10 @@ module.exports = {
         // only `aria-*` properties supported by that `role`
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
         'jsx-a11y/role-supports-aria-props': 'error',
+
+        // Enforce scope prop is only used on <th> elements.
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
+        'jsx-a11y/scope': 'error',
 
         // Enforce `tabIndex` value is not greater than zero
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md

--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -55,12 +55,12 @@ module.exports = {
         'jsx-a11y/aria-unsupported-elements': 'error',
 
         // Enforce an anchor element's `href` prop value is not just `#`
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash.md
-        'jsx-a11y/href-no-hash': 'error',
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+        'jsx-a11y/anchor-is-valid': 'error',
 
-        // Enforce that `<img>` JSX elements use the `alt` prop
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-has-alt.md
-        'jsx-a11y/img-has-alt': 'error',
+        // Enforce that `<img> <area> <input type="image"> <object>` JSX elements use the `alt` prop
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
+        'jsx-a11y/alt-text': 'error',
 
         // Enforce `<img>` alt prop does not contain the word "image", "picture", or "photo"
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
@@ -86,13 +86,13 @@ module.exports = {
         'jsx-a11y/no-onchange': 'off',
 
         // Enforce that elements with `onClick` handlers must be focusable
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-focus.md
-        'jsx-a11y/onclick-has-focus': 'error',
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
+        'jsx-a11y/interactive-supports-focus': 'error',
 
         // Enforce that non-interactive, visible elements (such as `<div>`)
         // that have click handlers use the role attribute
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-role.md
-        'jsx-a11y/onclick-has-role': 'error',
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md
+        'jsx-a11y/no-noninteractive-element-interactions': 'error',
 
         // Enforce that elements with ARIA roles must have all required attributes for that role
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md


### PR DESCRIPTION
It seems that some rules were added that were incompatible with existing version of jsx-a11y package, resulting in `rule not found` errors. The fix is to upgrade `eslint-plugin-jsx-a11y` and replace old rules with new ones! @jenjwong @rwholey-eb