### PR TITLE
Tweak ESLint configs

### DIFF
--- a/packages/eslint-config-eventbrite-react/rules/react-a11y.js
+++ b/packages/eslint-config-eventbrite-react/rules/react-a11y.js
@@ -1,27 +1,28 @@
 module.exports = {
     plugins: ['jsx-a11y'],
     extends: [
-        'plugin:jsx-a11y/strict',
+        'plugin:jsx-a11y/recommended',
     ],
 
     // View link below for docs on react a11y rules
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/
     rules: {
         // Enforce an anchor element contains a valid `href` attribute and if it can be replaced by a button
+        // (also checks react-router <Link to={...}>)
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
-        'jsx-a11y/anchor-is-valid': ['error', {components: ['Link']}],
+        'jsx-a11y/anchor-is-valid': ['error', {components: ['Link'], specialLink: ['to']}],
 
         // Enforce that `<label>` & (custom) <Label> elements have the `htmlFor` prop
+        // either the element is nested within or it has the `htmlFor` prop
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-        'jsx-a11y/label-has-for': ['error', {components: ['Label']}],
+        'jsx-a11y/label-has-for': ['error', {
+            components: ['Label'],
+            required: {some: ['id', 'nesting']},
+            allowChildren: true,
+        }],
 
         // Enforce lang attribute has a valid value.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
         'jsx-a11y/lang': 'error',
-
-        // Don't enforce that `onBlur` is used instead of (or more likely in parallel with) `onChange`
-        // NOTE: We may want to consider this later, but this has UX implications
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
-        'jsx-a11y/no-onchange': 'off',
     },
 };

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -92,11 +92,9 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
         'react/jsx-max-props-per-line': ['error', {maximum: 4}],
 
-        // Prevent arrow functions & refs in a JSX prop (but still allow bind for now)
+        // Prevent `.bind`, arrow functions & refs in a JSX prop
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
-        'react/jsx-no-bind': ['error', {
-            allowBind: true,
-        }],
+        'react/jsx-no-bind': 'error',
 
         // Prevent usage of unsafe target="_blank" w/o rel="noopener noreferrer"
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
@@ -164,9 +162,9 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-typos.md
         'react/no-typos': 'error',
 
-        // Prevent invalid characters from appearing in markup
+        // Prevent some characters from appearing in markup w/o being escaped
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md
-        'react/no-unescaped-entities': 'error',
+        'react/no-unescaped-entities': ['error', {forbid: ['>', '}', '"']}],
 
         // Prevent definitions of unused state
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md

--- a/packages/eslint-config-eventbrite/rules/es6.js
+++ b/packages/eslint-config-eventbrite/rules/es6.js
@@ -31,10 +31,6 @@ module.exports = {
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
         'import/export': 'error',
 
-        // enforce all exports appear after other statements
-        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md
-        'import/exports-last': 'error',
-
         // enforce all imports appear before other statements
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
         'import/first': 'error',


### PR DESCRIPTION
After merging #62, I tested the ESLint rules in EDS to see if they all made sense. Some of them needed some tweaks or flat out removal.

After this, we should be able to release new major versions of each package.