### PR TITLE
Move workspace root to repo root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ node_js:
   - "6"
 
 cache: yarn
-install: cd packages && yarn
+install: yarn
 
 script: yarn test
 
-before_deploy: cd packages
 deploy:
   # Deploy new version of eslint-config-eventbrite-legacy (but only on the "node" test matrix)
   - provider: script

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
     "private": true,
     "workspaces": [
-        "eslint-config-eventbrite-legacy",
-        "eslint-config-eventbrite",
-        "eslint-config-eventbrite-react"
+        "packages/*"
     ],
     "scripts": {
         "test": "yarn workspace eslint-config-eventbrite-legacy test && yarn workspace eslint-config-eventbrite test && yarn workspace eslint-config-eventbrite-react test"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,10 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-config-eventbrite-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/eslint-config-eventbrite-legacy/-/eslint-config-eventbrite-legacy-3.0.0.tgz#45fe0fa8d201a6edbd6135429de47712c90a3470"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"


### PR DESCRIPTION
From all the examples of Yarn workspaces I've seen, the `package.json` is at the repo root instead of in the `packages/` folder as we currently have it.

This actually makes life easier because there's no need to `cd packages` anymore to `yarn`, `yarn test` & `yarn publish`.