### PR TITLE
Remove travis-deploy-once in favor of node filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,24 @@ script: yarn test
 deploy:
   # Deploy new version of eslint-config-eventbrite-legacy (but only on the "node" test matrix)
   - provider: script
-    script: npx travis-deploy-once "yarn workspace eslint-config-eventbrite-legacy publish"
+    script: yarn workspace eslint-config-eventbrite-legacy publish
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-legacy-v.+$
+      node: "node"
 
   # Deploy new version of eslint-config-eventbrite (but only on the "node" test matrix)
   - provider: script
-    script: npx travis-deploy-once "yarn workspace eslint-config-eventbrite publish"
+    script: yarn workspace eslint-config-eventbrite publish
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-v.+$
+      node: "node"
 
   # Deploy new version of eslint-config-eventbrite-react (but only on the "node" test matrix)
   - provider: script
-    script: npx travis-deploy-once "yarn workspace eslint-config-eventbrite-react publish"
+    script: yarn workspace eslint-config-eventbrite-react publish
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-react-v.+$
+      node: "node"


### PR DESCRIPTION
For some reason `travis-deploy-once` needs `GITHUB_TOKEN` set in the environment (or passed in) in order to work, which makes no sense because we won't be writing anything to Github. It's probably because it's typically used with `semantic-release` which _does_ write to Github.

So instead, going to use the `node` conditional deployment filter and have it only deploy for the `"node"` job (i.e. latest version of node).