### PR TITLE
Switch to npm publish instead of yarn publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: yarn test
 deploy:
   # Deploy new version of eslint-config-eventbrite-legacy (but only on the "node" test matrix)
   - provider: script
-    script: yarn workspace eslint-config-eventbrite-legacy publish
+    script: npm publish packages/eslint-config-eventbrite-legacy
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-legacy-v.+$
@@ -21,7 +21,7 @@ deploy:
 
   # Deploy new version of eslint-config-eventbrite (but only on the "node" test matrix)
   - provider: script
-    script: yarn workspace eslint-config-eventbrite publish
+    script: npm publish packages/eslint-config-eventbrite
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-v.+$
@@ -29,7 +29,7 @@ deploy:
 
   # Deploy new version of eslint-config-eventbrite-react (but only on the "node" test matrix)
   - provider: script
-    script: yarn workspace eslint-config-eventbrite-react publish
+    script: npm publish packages/eslint-config-eventbrite-react
     on:
       tags: true
       condition: $TRAVIS_TAG =~ ^eslint-config-eventbrite-react-v.+$


### PR DESCRIPTION
`yarn publish` for some reason asks for the new version of the package, makes it pretty much useless in a CI environment. I want it to just publish the files at the version _already_ in the `package.json`. This is what `npm publish` does so switching to that in hopes that it works as intended.