### PR TITLE
Add .npmrc file to set authToken

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ install: yarn
 
 script: yarn test
 
+before_deploy:
+  # Write the authentication token to .npmrc right before we're about to deploy.
+  # We cannot check this file in because then it'll try to authenticate on yarn install.
+  # And that is bad because $NPM_TOKEN isn't available in all PRs
+  # (see https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions).
+  # We only need the token for publishing the package so we'll create the .npmrc file right before.
+  - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
 deploy:
   # Deploy new version of eslint-config-eventbrite-legacy (but only on the "node" test matrix)
   - provider: script


### PR DESCRIPTION
[`Build #88`](https://travis-ci.org/eventbrite/javascript/jobs/383401916) failed because of an authorization error.

In Travis we have `NPM_TOKEN` as an environment variable, but it's not automagically read. We need to update the registry URL to include it per: https://docs.npmjs.com/private-modules/ci-server-config#setting-up-a-project-specific-npmrc-file.

Then `npm publish` should have the authorization it needs.

Tried committing a `.npmrc` file (see [`Build #89`](https://travis-ci.org/eventbrite/javascript/builds/383421546)), but that broke PRs because `NPM_TOKEN` isn't available in builds from PRs the outside. So instead in `before_deploy` we'll create the `.npmrc` file on the fly. This is was `semantic-release` and other utilities do behind the scenes.