### PR TITLE
Add skip_cleanup to each deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_deploy:
 deploy:
   # Deploy new version of eslint-config-eventbrite-legacy (but only on the "node" test matrix)
   - provider: script
+    skip_cleanup: true
     script: npm publish packages/eslint-config-eventbrite-legacy
     on:
       tags: true
@@ -28,6 +29,7 @@ deploy:
 
   # Deploy new version of eslint-config-eventbrite (but only on the "node" test matrix)
   - provider: script
+    skip_cleanup: true
     script: npm publish packages/eslint-config-eventbrite
     on:
       tags: true
@@ -36,6 +38,7 @@ deploy:
 
   # Deploy new version of eslint-config-eventbrite-react (but only on the "node" test matrix)
   - provider: script
+    skip_cleanup: true
     script: npm publish packages/eslint-config-eventbrite-react
     on:
       tags: true


### PR DESCRIPTION
Based on [`Build #92`](https://travis-ci.org/eventbrite/javascript/jobs/383442045), Travis cleans up the build artificats (`git stash --all`) **after** `before_deploy` is run and before `deploy` is executed. This means that the temporary `.npmrc` file that was written with PR #70 was removed before deploying. As a result no authentication again.

Passing `skip_cleanup: true` should do the trick. Not sure if it needs to be passed to each or if it could be shared at the top under `deploy`, but going the safe route and adding to each.