### PR TITLE
 Add updated CHANGELOG for 3 eslint packages

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/CHANGELOG.md
+++ b/packages/eslint-config-eventbrite-legacy/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v4.0.0 (May 24, 2018)
+- (major) Requires node >= 6
+- (major) Bumped `eslint` peer dependency to `^4.19.1`
+- (major) **New** erroring rules:
+  * [accessor-pairs](https://eslint.org/docs/rules/accessor-pairs)
+  * [func-name-matching](https://eslint.org/docs/rules/func-name-matching)
+  * [no-catch-shadow](https://eslint.org/docs/rules/no-catch-shadow)
+  * [no-extend-native](https://eslint.org/docs/rules/no-extend-native)
+  * [no-lonely-if](http://eslint.org/docs/rules/no-lonely-if)
+  * [no-multi-assign](http://eslint.org/docs/rules/no-multi-assign)
+  * [no-shadow](https://eslint.org/docs/rules/no-shadow)
+  * [no-shadow-restricted-names](https://eslint.org/docs/rules/no-shadow-restricted-names)
+  * [no-trailing-spaces](http://eslint.org/docs/rules/no-trailing-spaces)
+  * [no-unneeded-ternary](http://eslint.org/docs/rules/no-unneeded-ternary)
+  * [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define)
+  * [no-useless-return](http://eslint.org/docs/rules/no-useless-return)
+  * [semi-spacing](http://eslint.org/docs/rules/semi-spacing)
+- (major) Stronger exiting erroring rules:
+  * [new-cap](http://eslint.org/docs/rules/new-cap) no longer w/ any exceptions
+
 ## v3.0.0 (February 10, 2017)
 - (major) remove `env` & `globals` directives
 - (major) reenable `no-unused-expressions` to be an error

--- a/packages/eslint-config-eventbrite-react/CHANGELOG.md
+++ b/packages/eslint-config-eventbrite-react/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v5.0.0 (May 24, 2018)
+- (major) Requires node >= 6
+- (major) bump `eslint-config-eventbrite-legacy` to `^4.0.0`
+- (major) Bumped `eslint` peer dependency to `^4.19.1`
+- (major) Bumped `babel-eslint` peer dependency to `^8.2.3`
+- (minor) Bumped `eslint-plugin-import` peer dependency to `^2.11.0`
+- (major) Added `eslint-plugin-babel` peer dependency at `^5.1.0`
+- (major) Added `eslint-plugin-jest` peer dependency at `^21.15.1`
+- (major) Bumped `esling-plugin-react` peer dependency to `^7.7.0`
+- (major) New erroring rules:
+  * Everything within [plugin:jsx-a11y/recommended](https://github.com/evcohen/eslint-plugin-jsx-a11y/), particularly [jsx-a11y/no-onchange](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md)
+  * [react/button-has-type](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)
+  * [react/default-props-match-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md)
+  * [react/forbid-foreign-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
+  * [react/jsx-curly-brace-presence](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md)
+  * [react/no-access-state-in-setstate](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)
+  * [react/no-array-index-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
+  * [react/no-deprecated](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md)
+  * [react/no-find-dom-node](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)
+  * [react/no-redundant-should-component-update](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md)
+  * [react/no-this-in-sfc](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md)
+  * [react/no-typos](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-typos.md)
+  * [react/no-unescaped-entities](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md)
+  * [react/no-unused-state](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md)
+  * [react/prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+  * [react/void-dom-elements-no-children](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
+- (major) Stronger exiting erroring rules:
+  * [react/jsx-no-bind](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) prevents `.bind()` as well as arrow functions & refs in JSX props
+  * [react/jsx-tag-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)
+- (patch) Relaxed existing erroring rules:
+  * [jsx-a11y/anchor-is-valid](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md) to not complain about `<Link to={...}>`
+  * [jsx-a11y/label-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) to support `<label>` or `<Label>` with text contents
+  * [react/jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md) only requires prop on separate line when there are multiple props AND the component spans multiple lines
+  * [react/jsx-max-props-per-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md) now allows 4 props per line (up from 3)
+
 ## v4.0.0 (April 28, 2017)
 - (major) Add new `jsx-a11y` rules
 

--- a/packages/eslint-config-eventbrite-react/CHANGELOG.md
+++ b/packages/eslint-config-eventbrite-react/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v5.0.0 (May 24, 2018)
+## v6.0.0 (May 24, 2018)
 - (major) Requires node >= 6
 - (major) bump `eslint-config-eventbrite-legacy` to `^4.0.0`
 - (major) Bumped `eslint` peer dependency to `^4.19.1`
@@ -32,6 +32,9 @@
   * [jsx-a11y/label-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) to support `<label>` or `<Label>` with text contents
   * [react/jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md) only requires prop on separate line when there are multiple props AND the component spans multiple lines
   * [react/jsx-max-props-per-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md) now allows 4 props per line (up from 3)
+
+## v5.0.0 (July 5, 2017)
+- (major) Replace old `jsx-a11y` rules
 
 ## v4.0.0 (April 28, 2017)
 - (major) Add new `jsx-a11y` rules

--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -108,7 +108,7 @@ module.exports = {
         // Forbid spaces before the closing bracket
         // Enforce spaces before the closing bracket of self-closing elements
         // Forbid spaces between the angle bracket and slash of JSX closing or self-closing elements
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md
         'react/jsx-tag-spacing': ['error', {
             afterOpening: 'never',
             beforeClosing: 'never',
@@ -158,7 +158,7 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md
         'react/no-this-in-sfc': 'error',
 
-        // Prevent using (legacy) string references in ref attribute
+        // Prevents common typos made declaring static class properties and lifecycle methods
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-typos.md
         'react/no-typos': 'error',
 

--- a/packages/eslint-config-eventbrite/CHANGELOG.md
+++ b/packages/eslint-config-eventbrite/CHANGELOG.md
@@ -25,6 +25,7 @@
 - (major) Added `eslint-plugin-babel` peer dependency at `^5.1.0`
   * [babel/no-invalid-this](https://github.com/babel/eslint-plugin-babel/) replaces [no-invalid-this](http://eslint.org/docs/rules/no-invalid-this)
 - (major) Added `eslint-plugin-jest` peer dependency at `^21.15.1`
+  * Everything within [plugin:jest/recommended](https://github.com/jest-community/eslint-plugin-jest#rules)
   * [jest/consistent-test-it](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/consistent-test-it.md)
   * [jest/lowercase-name](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/lowercase-name.md)
   * [jest/prefer-to-be-null](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-null.md)

--- a/packages/eslint-config-eventbrite/CHANGELOG.md
+++ b/packages/eslint-config-eventbrite/CHANGELOG.md
@@ -1,3 +1,37 @@
+## v5.0.0 (May 24, 2018)
+- (major) Requires node >= 6
+- (major) bump `eslint-config-eventbrite-legacy` to `^4.0.0`
+- (major) Bumped `eslint` peer dependency to `^4.19.1`
+- (major) Bumped `babel-eslint` peer dependency to `^8.2.3`
+- (minor) Bumped `eslint-plugin-import` peer dependency to `^2.11.0`
+- (major) New erroring rules:
+  * [import/default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md)
+  * [import/named](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md)
+  * [import/namespace](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md)
+  * [import/no-amd](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md)
+  * [import/no-commonjs](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md)
+  * [import/no-cycle](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md)
+  * [import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)
+  * [import/no-named-as-default-member](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md)
+  * [import/no-named-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md)
+  * [import/no-self-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md)
+  * [import/no-useless-path-segments](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-useless-path-segments.md)
+  * [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
+  * [no-return-await](https://eslint.org/docs/rules/no-return-await)
+  * [strict](https://eslint.org/docs/rules/strict)
+- (major) Stronger exiting erroring rules:
+  * [comma-dangle](http://eslint.org/docs/rules/comma-dangle) is turned on for `import` & `export`
+  * [prefer-const](http://eslint.org/docs/rules/prefer-const) is turned on enforce using `const` whenever possible
+- (major) Added `eslint-plugin-babel` peer dependency at `^5.1.0`
+  * [babel/no-invalid-this](https://github.com/babel/eslint-plugin-babel/) replaces [no-invalid-this](http://eslint.org/docs/rules/no-invalid-this)
+- (major) Added `eslint-plugin-jest` peer dependency at `^21.15.1`
+  * [jest/consistent-test-it](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/consistent-test-it.md)
+  * [jest/lowercase-name](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/lowercase-name.md)
+  * [jest/prefer-to-be-null](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-null.md)
+  * [jest/prefer-to-be-undefined](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-undefined.md)
+  * [jest/valid-describe](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-describe.md)
+  * [jest/valid-expect-in-promise](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md)
+
 ## v4.0.0 (February 10, 2017)
 - (major) bump `eslint-config-eventbrite-legacy` to 3.0.0
 


### PR DESCRIPTION
Lists out the new rules added, those made stronger, and those relaxed across `eslint-config-eventbrite-legacy`, `eslint-config-eventbrite` & `eslint-config-eventbrite-react`.

Also noticed one incorrect URL in the rules definition.

Also realized that we had forgotten to include v5 of `eslint-config-eventbrite-react` in the CHANGELOG.