### PR TITLE
Removes arrow-body-style rule in ES6 eslint rules

### DIFF
--- a/packages/eslint-config-eventbrite/rules/es6.js
+++ b/packages/eslint-config-eventbrite/rules/es6.js
@@ -11,10 +11,6 @@ module.exports = {
     plugins: ['import'],
     extends: ['plugin:import/errors'],
     rules: {
-        // require no braces where they can be omitted
-        // http://eslint.org/docs/rules/arrow-body-style
-        'arrow-body-style': 'error',
-
         // require parentheses around arrow function parameters
         // http://eslint.org/docs/rules/arrow-parens
         'arrow-parens': 'error',


### PR DESCRIPTION
This rule is nice to remind developers the fact that we can return a single operation from an arrow function without needing the 'return' clause. However, it is also problematic due to several things:

First, this rule doesn't take into account that maybe that single return value is composed of a chain of operations, so it won't be as readable if returned all at once.

Second, when debugging a react application, sometimes we want to add a 'debugger' clause in the code before the return. When this happens, we are forced to first, add curly braces and a return statement, then add the debugger, and once we end debugging, undo the previous operations to not break this rule. This can be annoying and a waste of time.

In this PR, I suggest to get rid of the rule altogether, but I would be also open to just change it to not throw an error.