### PR TITLE
Inverts the ESLint rule that forces us to remove padding within curly braces of object literals

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/rules/style.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/style.js
@@ -104,7 +104,7 @@ module.exports = {
 
         // disallow padding within curly braces of object literals
         // http://eslint.org/docs/rules/object-curly-spacing
-        'object-curly-spacing': 'error',
+        'object-curly-spacing': ['error', 'always'],
 
         // enforce that `var` declarations are declared together
         // http://eslint.org/docs/rules/one-var


### PR DESCRIPTION
This rule is a stylistic requirement that forces us to remove the padding between values of an object literal, and that mainly applies when we are destructuring values from an object or in parameter destructuring in the signature of a function.

The proposed change is making it the contrary, that means, to force us to add padding with spaces on this cases. The benefits I consider this brings are twofold:

First, we improve the readability of our code, being:

     let { velocity } = parameters;
     const fn = ({ velocity }) => velocity;

More readable than:

     let {velocity} = parameters;
     const fn = ({velocity}) => velocity;

Second, we are more in sync with what the JavaScript community in general does, as this rule is set up the proposed way in a code style guide as important as the AirBnB one. Also, a lot of examples out there use the padded version.

In this case, I understand this is more a stylistic proposal, although I really think the readability benefits are real.