### PR TITLE
Add keyword spacing lint rule

### DIFF
--- a/packages/eslint-config-eventbrite-legacy/rules/style.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/style.js
@@ -147,6 +147,6 @@ module.exports = {
 
         // require spacing before and after keywords
         // https://eslint.org/docs/rules/keyword-spacing
-        'keyword-spacing': 'error',
+        'keyword-spacing': 'error'
     }
 };

--- a/packages/eslint-config-eventbrite-legacy/rules/style.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/style.js
@@ -143,6 +143,10 @@ module.exports = {
 
         // never have a space before function parentheses
         // http://eslint.org/docs/rules/space-before-function-paren
-        'space-before-function-paren': ['error', 'never']
+        'space-before-function-paren': ['error', 'never'],
+
+        // require spacing before and after keywords
+        // https://eslint.org/docs/rules/keyword-spacing
+        'keyword-spacing': 'error',
     }
 };

--- a/packages/eslint-config-eventbrite-legacy/rules/style.js
+++ b/packages/eslint-config-eventbrite-legacy/rules/style.js
@@ -44,13 +44,17 @@ module.exports = {
             SwitchCase: 1
         }],
 
-        // disallow inline comments after code
-        // http://eslint.org/docs/rules/line-comment-position
-        'line-comment-position': 'error',
-
         // space for values in object literals
         // http://eslint.org/docs/rules/key-spacing
         'key-spacing': 'error',
+
+        // require spacing before and after keywords
+        // https://eslint.org/docs/rules/keyword-spacing
+        'keyword-spacing': 'error',
+
+        // disallow inline comments after code
+        // http://eslint.org/docs/rules/line-comment-position
+        'line-comment-position': 'error',
 
         // Require constructor function names to begin with a capital letter
         // Requires all `new` operators to be called with uppercase-started functions.
@@ -143,10 +147,6 @@ module.exports = {
 
         // never have a space before function parentheses
         // http://eslint.org/docs/rules/space-before-function-paren
-        'space-before-function-paren': ['error', 'never'],
-
-        // require spacing before and after keywords
-        // https://eslint.org/docs/rules/keyword-spacing
-        'keyword-spacing': 'error'
+        'space-before-function-paren': ['error', 'never']
     }
 };

--- a/packages/eslint-config-eventbrite/rules/best-practices.js
+++ b/packages/eslint-config-eventbrite/rules/best-practices.js
@@ -4,6 +4,5 @@ module.exports = {
         // disallow modifying properties of parameters
         // http://eslint.org/docs/rules/no-param-reassign
         'no-param-reassign': ['error', {props: true}],
-        'keyword-spacing': 'error'
     },
 };

--- a/packages/eslint-config-eventbrite/rules/best-practices.js
+++ b/packages/eslint-config-eventbrite/rules/best-practices.js
@@ -4,5 +4,6 @@ module.exports = {
         // disallow modifying properties of parameters
         // http://eslint.org/docs/rules/no-param-reassign
         'no-param-reassign': ['error', {props: true}],
+        'keyword-spacing': 'error'
     },
 };


### PR DESCRIPTION
Adds rule to enforce spacing before and after keywords which is a common best readability practice in JavaScript. Makes sure that this:

```
if(foo){
    // ...
}else{
    // ...
}
```

Is written as:

```
if (foo) {
    // ...
} else {
    // ...
}
```

Hattip to @melissaroman-eb for finding this style inconsistency in a recent diff I posted.

Fixes #79 