### PR TITLE
Remove rule forbidding multiple class style component declarations

### DIFF
--- a/packages/eslint-config-eventbrite-react/rules/react.js
+++ b/packages/eslint-config-eventbrite-react/rules/react.js
@@ -141,11 +141,6 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md
         'react/no-find-dom-node': 'error',
 
-        // Prevent multiple component definitions in a given file
-        // (stateless helper components are ok)
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-        'react/no-multi-comp': ['error', {ignoreStateless: true}],
-
         // Prevent usage of `shouldComponentUpdate` when extending `React.PureComponent`
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md
         'react/no-redundant-should-component-update': 'error',


### PR DESCRIPTION
We have established at EB a way that we write react code, and many components utilize functional helper components to abstract portions of a larger, more complex, component. 

As we continue with this pattern we miss out on the potential performance boosts PureComponents provide as stateless functional components default to standard behavior.

React 16.6 introduced the `memo` api for stateless components: https://reactjs.org/blog/2018/10/23/react-v-16-6.html but until we get to that point (and decide if that is the pattern we want to use) I believe we are losing potential performance increases provided by react. So I vote to remove it so we can enable ourselves to be more performant :) 

ps. If instances of "component dumping grounds" (one of the original impetuses for this rule) begin to occur then maybe will require revisiting or introducing a variant of this rule.